### PR TITLE
大佬，发现您的项目引入了io.netty:netty-all@4.1.10.Final组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.springframework.boot</groupId>
@@ -33,7 +32,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId> <!-- Use 'netty-all' for 4.0 or above -->
-            <version>4.1.10.Final</version>
+            <version>4.1.44.Final</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Netty 环境问题漏洞
缺陷组件：io.netty:netty-all@4.1.10.Final
漏洞编号：CVE-2019-20445
漏洞描述：Netty是Netty社区的一款非阻塞I/O客户端-服务器框架，它主要用于开发Java网络应用程序，如协议服务器和客户端等。
Netty 4.1.44之前版本中的HttpObjectDecoder.java文件存在环境问题漏洞。该漏洞源于网络系统或产品的环境因素不合理。
影响范围：(∞, 4.1.44.Final)
最小修复版本：4.1.44.Final
缺陷组件引入路径：cn.zhang:SpringCloudRpc@1.0.0->io.netty:netty-all@4.1.10.Final
```
另外我运行这个项目时，IDE的安全插件提示还有14个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p7a8ab